### PR TITLE
Add core and infrastructure projects based on clean architecture

### DIFF
--- a/tulsa-dnug-website.core/tulsa-dnug-website.core.csproj
+++ b/tulsa-dnug-website.core/tulsa-dnug-website.core.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <RootNamespace>tulsa_dnug_website.core</RootNamespace>
+  </PropertyGroup>
+
+</Project>

--- a/tulsa-dnug-website.infrastructure/tulsa-dnug-website.infrastructure.csproj
+++ b/tulsa-dnug-website.infrastructure/tulsa-dnug-website.infrastructure.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <RootNamespace>tulsa_dnug_website.infrastructure</RootNamespace>
+  </PropertyGroup>
+
+</Project>

--- a/tulsa-dnug-website.sln
+++ b/tulsa-dnug-website.sln
@@ -1,9 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28714.193
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "tulsa-dnug-website", "tulsa-dnug-website\tulsa-dnug-website.csproj", "{3154109C-1F8A-4C8C-AB65-7BBCE9EDE730}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "tulsa-dnug-website", "tulsa-dnug-website\tulsa-dnug-website.csproj", "{3154109C-1F8A-4C8C-AB65-7BBCE9EDE730}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "tulsa-dnug-website.core", "tulsa-dnug-website.core\tulsa-dnug-website.core.csproj", "{DA1432A5-A13F-4EF7-BD09-2997D45C9C14}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "tulsa-dnug-website.infrastructure", "tulsa-dnug-website.infrastructure\tulsa-dnug-website.infrastructure.csproj", "{084EB71E-2433-4529-B2FD-AF6453487A61}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -13,9 +17,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{3154109C-1F8A-4C8C-AB65-7BBCE9EDE730}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -30,5 +31,35 @@ Global
 		{3154109C-1F8A-4C8C-AB65-7BBCE9EDE730}.Release|x64.Build.0 = Release|Any CPU
 		{3154109C-1F8A-4C8C-AB65-7BBCE9EDE730}.Release|x86.ActiveCfg = Release|Any CPU
 		{3154109C-1F8A-4C8C-AB65-7BBCE9EDE730}.Release|x86.Build.0 = Release|Any CPU
+		{DA1432A5-A13F-4EF7-BD09-2997D45C9C14}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DA1432A5-A13F-4EF7-BD09-2997D45C9C14}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DA1432A5-A13F-4EF7-BD09-2997D45C9C14}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DA1432A5-A13F-4EF7-BD09-2997D45C9C14}.Debug|x64.Build.0 = Debug|Any CPU
+		{DA1432A5-A13F-4EF7-BD09-2997D45C9C14}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DA1432A5-A13F-4EF7-BD09-2997D45C9C14}.Debug|x86.Build.0 = Debug|Any CPU
+		{DA1432A5-A13F-4EF7-BD09-2997D45C9C14}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DA1432A5-A13F-4EF7-BD09-2997D45C9C14}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DA1432A5-A13F-4EF7-BD09-2997D45C9C14}.Release|x64.ActiveCfg = Release|Any CPU
+		{DA1432A5-A13F-4EF7-BD09-2997D45C9C14}.Release|x64.Build.0 = Release|Any CPU
+		{DA1432A5-A13F-4EF7-BD09-2997D45C9C14}.Release|x86.ActiveCfg = Release|Any CPU
+		{DA1432A5-A13F-4EF7-BD09-2997D45C9C14}.Release|x86.Build.0 = Release|Any CPU
+		{084EB71E-2433-4529-B2FD-AF6453487A61}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{084EB71E-2433-4529-B2FD-AF6453487A61}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{084EB71E-2433-4529-B2FD-AF6453487A61}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{084EB71E-2433-4529-B2FD-AF6453487A61}.Debug|x64.Build.0 = Debug|Any CPU
+		{084EB71E-2433-4529-B2FD-AF6453487A61}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{084EB71E-2433-4529-B2FD-AF6453487A61}.Debug|x86.Build.0 = Debug|Any CPU
+		{084EB71E-2433-4529-B2FD-AF6453487A61}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{084EB71E-2433-4529-B2FD-AF6453487A61}.Release|Any CPU.Build.0 = Release|Any CPU
+		{084EB71E-2433-4529-B2FD-AF6453487A61}.Release|x64.ActiveCfg = Release|Any CPU
+		{084EB71E-2433-4529-B2FD-AF6453487A61}.Release|x64.Build.0 = Release|Any CPU
+		{084EB71E-2433-4529-B2FD-AF6453487A61}.Release|x86.ActiveCfg = Release|Any CPU
+		{084EB71E-2433-4529-B2FD-AF6453487A61}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {66C8AEA5-55D7-46A8-AAE2-93872F6DA87E}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Based on the clean architecture example by @ardalis (Steve Smith), we added the Core project to contain common files used throughout the application and the Infrastructure project to contain communication with external services